### PR TITLE
Change branch for hdf5 `master`->`develop`

### DIFF
--- a/org.gnome.gxsm4.json
+++ b/org.gnome.gxsm4.json
@@ -74,7 +74,7 @@
                 {
 		    "type"   : "git",
 		    "url"    : "https://github.com/HDFGroup/hdf5.git",
-		    "branch" : "master"
+		    "branch" : "develop"
                 }
             ]
         },


### PR DESCRIPTION
hdf5 now does not provide a `master` branch anymore ans instead uses `develop`.