### PR TITLE
Typo and adjust flatpak build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ Install flatpak and flathub
 ```
 Install the gnome sdk within your flatpak enviroment:
 ``` 
- $ mkdir flatpak
  $ flatpak install flathub org.gnome.Sdk//41 org.gnome.Platform//41
 ```
 
 Now install and run GXSM4 (assuming that the json-file/source is in the folder gxsm4-git
 ``` 
- $ flatpak-builder flaatpak gxsm4-git/org.gnome.gxsm4.json
- $ flatpak-builder --user --install --force-clean flatpak gxsm4-git/org.gnome.gxsm4.json
+ $ mkdir flatpak_builder_dir
+ $ flatpak-builder --user --install --force-clean flatpak_builder_dir gxsm4-git/org.gnome.gxsm4.json
  $ flatpak run org.gnome.gxsm4
 ```
  


### PR DESCRIPTION
I am farily sure, that `flatpak-builder flatpak org.gnome.gxsm4.json` is unecassary if `flatpak-builder --user --install --force-clean flatpak_builder_dir gxsm4-git/org.gnome.gxsm4.json` is used since `--force-clean` will remove all the files generated by the previous command.