### PR TITLE
Update meson.build - setting zlib to required : false

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,7 @@ fftw  = dependency('fftw3')
 xml   = dependency('libxml-2.0')
 gmod  = dependency('gmodule-2.0')
 gmodexp = dependency('gmodule-export-2.0')
-lz    = dependency('zlib', method : 'system')
+lz    = dependency('zlib', method : 'system', required: false)
 #lz    = cc.find_library('z')
 
 icuuc = cc.find_library('icuuc')


### PR DESCRIPTION
zlib dependy caused problems building via flatpak